### PR TITLE
Disable Wine systray icon

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -45,6 +45,7 @@
             #!/bin/sh
             export WINEPREFIX="\$HOME/.wine-kakaotalk"
             export WINEARCH=win64
+            export WINE_NO_TRAY_ICON=1
 
             # Setup wine prefix if it doesn't exist
             if [ ! -d "\$WINEPREFIX" ]; then


### PR DESCRIPTION
## Summary
- prevent the Wine systray icon from appearing

## Testing
- `nix` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684bddb1a2488329bbe82de2c1c89176

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated the KakaoTalk launcher to suppress the Wine system tray icon during use.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->