### PR TITLE
Fix quoting in KakaoTalk launcher

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -42,7 +42,7 @@
             # Create launcher script
             cat > $out/bin/kakaotalk <<EOF
             #!/usr/bin/env bash
-            PREFIX="${XDG_DATA_HOME:-$HOME/.local/share}/kakaotalk"
+            PREFIX="\${XDG_DATA_HOME:-$HOME/.local/share}/kakaotalk"
             INSTALLER="$out/share/kakaotalk/KakaoTalk_Setup.exe"
             FONT_SOURCE=${noto-fonts-cjk-sans}/share/fonts
 


### PR DESCRIPTION
## Summary
- escape shell interpolation in launcher script

## Testing
- `nix flake show` *(fails: `nix: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_684bee13005c8329a4bcd6a7db6553f8