### PR TITLE
chore: run nvfetcher

### DIFF
--- a/_sources/generated.json
+++ b/_sources/generated.json
@@ -1,6 +1,6 @@
 {
     "kakaotalk-exe": {
-        "cargoLock": null,
+        "cargoLocks": null,
         "date": null,
         "extract": null,
         "name": "kakaotalk-exe",
@@ -8,14 +8,14 @@
         "pinned": false,
         "src": {
             "name": null,
-            "sha256": "sha256-EEePn6PZPUqc4w9KojHEw9aI+s4WifKdKyYZHhweiMU=",
+            "sha256": "sha256-R1/bSdG81VOMYuXbYIQPUafAd3FC3+OROcu46aAVeog=",
             "type": "url",
             "url": "https://app-pc.kakaocdn.net/talk/win32/KakaoTalk_Setup.exe"
         },
         "version": "0.0.0"
     },
     "kakaotalk-icon": {
-        "cargoLock": null,
+        "cargoLocks": null,
         "date": null,
         "extract": null,
         "name": "kakaotalk-icon",

--- a/_sources/generated.nix
+++ b/_sources/generated.nix
@@ -6,7 +6,7 @@
     version = "0.0.0";
     src = fetchurl {
       url = "https://app-pc.kakaocdn.net/talk/win32/KakaoTalk_Setup.exe";
-      sha256 = "sha256-EEePn6PZPUqc4w9KojHEw9aI+s4WifKdKyYZHhweiMU=";
+      sha256 = "sha256-R1/bSdG81VOMYuXbYIQPUafAd3FC3+OROcu46aAVeog=";
     };
   };
   kakaotalk-icon = {


### PR DESCRIPTION
All I did was to run `nvfetcher` in anticipation for this to work (without even reading nvfetcher's manual) and it worked! The autogenerated nix files had seen a few changes to its field names probably due to deprecation, but it probably does not matter.